### PR TITLE
non-official apps identification

### DIFF
--- a/kraken-generic/src/main/java/org/wikimedia/analytics/kraken/pageview/UserAgent.java
+++ b/kraken-generic/src/main/java/org/wikimedia/analytics/kraken/pageview/UserAgent.java
@@ -48,13 +48,21 @@ public class UserAgent {
     //private static final Pattern WMF_APP_FIREFOX_UA_PAT   = Pattern.compile("Mozilla/5.0 \\(Mobile; rv:.*\\) Gecko/.* Firefox/.*");
     //private static final Pattern WMF_APP_WINDOWS_UA_PAT   = Pattern.compile("Mozilla/5.0 \\(compatible; MSIE 10.0; Windows NT.*\\)");
 
-    private static final Map<String, Pattern> WMF_APP_PATTERNS = new HashMap<String, Pattern>();
+    private static final Pattern NON_WMF_APP_IOS_UA_PAT     = Pattern.compile( "^.+CFNetwork/[0-9.]+Darwin/" );
+
+    private static final Map<String, Pattern>
+	    WMF_APP_PATTERNS = new HashMap<String, Pattern>(),
+	    NON_WMF_APP_PATTERNS = new HashMap<String, Pattern>();
     static {
+	    // WMF app
         WMF_APP_PATTERNS.put("Android",             WMF_APP_ANDROID_UA_PAT);
         WMF_APP_PATTERNS.put("Firefox OS",          WMF_APP_FIREFOX_UA_PAT);
         WMF_APP_PATTERNS.put("BlackBerry PlayBook", WMF_APP_RIM_UA_PAT);
         WMF_APP_PATTERNS.put("Windows 8",           WMF_APP_WINDOWS_UA_PAT);
         WMF_APP_PATTERNS.put("iOS",                 WMF_APP_IOS);
+
+	    // non-WMF app
+        NON_WMF_APP_PATTERNS.put("iOS non-WMF",  NON_WMF_APP_IOS_UA_PAT);
     }
 
 
@@ -66,6 +74,7 @@ public class UserAgent {
     private String deviceOsVersion;
     private String deviceClass;
     private String wmfMobileApp;
+    private String nonWmfMobileApp;
 
 
 
@@ -148,6 +157,13 @@ public class UserAgent {
                 return;
             }
         }
+        for (Map.Entry<String, Pattern> entry : NON_WMF_APP_PATTERNS.entrySet()) {
+            pattern = entry.getValue();
+            if (pattern.matcher(userAgent).find()) {
+                nonWmfMobileApp = entry.getKey();
+                return;
+            }
+        }
     }
 
 
@@ -209,6 +225,10 @@ public class UserAgent {
 
     public String getWMFMobileApp() {
         return wmfMobileApp;
+    }
+
+    public String getNonWMFMobileApp() {
+        return nonWmfMobileApp;
     }
 
     public String getInputDevices() {

--- a/kraken-pig/src/main/java/org/wikimedia/analytics/kraken/pig/UserAgentClassifier.java
+++ b/kraken-pig/src/main/java/org/wikimedia/analytics/kraken/pig/UserAgentClassifier.java
@@ -102,7 +102,7 @@ public class UserAgentClassifier extends EvalFunc<Tuple> {
 
         UserAgent userAgent = new UserAgent(input.get(0).toString());
 
-        Tuple output = tupleFactory.newTuple(11);
+        Tuple output = tupleFactory.newTuple(12);
         output.set(0, userAgent.getParentId()); // XXX: should be vendor?
         output.set(1, userAgent.getModel());
         output.set(2, userAgent.getDeviceOs());
@@ -114,6 +114,7 @@ public class UserAgentClassifier extends EvalFunc<Tuple> {
         output.set(8, userAgent.getAjaxSupportJavascript());
         output.set(9, userAgent.getDisplayDimensions());
         output.set(10, userAgent.getInputDevices());
+        output.set(11, userAgent.getNonWMFMobileApp());
 
         return output;
     }

--- a/kraken-pig/src/test/java/org/wikimedia/analytics/kraken/pig/UserAgentClassifierTest.java
+++ b/kraken-pig/src/test/java/org/wikimedia/analytics/kraken/pig/UserAgentClassifierTest.java
@@ -121,6 +121,33 @@ public class UserAgentClassifierTest {
     }
 
     @Test
+    public void testIOSNonWikimediaApp() throws IOException, ParseException{
+        UserAgentClassifier ua = new UserAgentClassifier();
+        Tuple input =  tupleFactory.newTuple(1);
+
+	final int id = 11;
+        input.set(0, "Wikipanion/1.7.8.3.CFNetwork/609.1.4.Darwin/13.0.0");
+        Tuple output = ua.exec(input);
+        assertEquals("iOS non-WMF", output.get(id));
+
+        input.set(0, ".Wikibot/2.0.2.CFNetwork/609.1.4.Darwin/13.0.0");
+        output = ua.exec(input);
+        assertEquals("iOS non-WMF", output.get(id));
+
+        input.set(0, ".OnThisDay/48.CFNetwork/609.1.4.Darwin/13.0.0");
+        output = ua.exec(input);
+        assertEquals("iOS non-WMF", output.get(id));
+
+        input.set(0, ".WikiHunt/1.7.CFNetwork/609.1.4.Darwin/13.0.0.");
+        output = ua.exec(input);
+        assertEquals("iOS non-WMF", output.get(id));
+
+        input.set(0, ".Articles/285.CFNetwork/609.1.4.Darwin/13.0.0");
+        output = ua.exec(input);
+        assertEquals("iOS non-WMF", output.get(id));
+    }
+
+    @Test
     public void testIPhone5() throws IOException, ParseException{
         UserAgentClassifier ua = new UserAgentClassifier();
         Tuple input =  tupleFactory.newTuple(1);


### PR DESCRIPTION
This change adds a regular expression to match the user agent string from some of the
non-official WMF apps on IOS along with unit tests.
